### PR TITLE
feat: expand tests for deno.json and deno.jsonc

### DIFF
--- a/__fixtures__/complex-deno/deno.jsonc
+++ b/__fixtures__/complex-deno/deno.jsonc
@@ -2,27 +2,6 @@
   "workspace": [
     "packages/*"
   ],
-  "nodeModulesDir": "auto",
-  "tasks": {
-    "check": "deno fmt --check . && deno lint . && deno check",
-    "dev": "vite",
-    "build": "vite build",
-    "start": "deno serve -A _fresh/server.js",
-    "update": "deno run -A -r jsr:@fresh/update .",
-    "check-deps": "deno run -A jsr:@check/deps --allow-unused"
-  },
-  "lint": {
-    "rules": {
-      "tags": [
-        "fresh",
-        "recommended"
-      ]
-    }
-  },
-  // "broken:", "this should not be here",
-  "exclude": [
-    "**/_fresh/*"
-  ],
   "imports": {
     "@/": "./",
     "class-variance-authority": "npm:class-variance-authority@^0.7.1",
@@ -41,31 +20,5 @@
     "vite": "npm:vite@^7.1.4",
     "tailwindcss": "npm:tailwindcss@^4.1.12",
     "@tailwindcss/vite": "npm:@tailwindcss/vite@^4.1.12"
-  },
-  "compilerOptions": {
-    "lib": [
-      "dom",
-      "dom.asynciterable",
-      "dom.iterable",
-      "deno.ns"
-    ],
-    "jsx": "precompile",
-    "jsxImportSource": "preact",
-    "jsxPrecompileSkipElements": [
-      "a",
-      "img",
-      "source",
-      "body",
-      "html",
-      "head",
-      "title",
-      "meta",
-      "script",
-      "link",
-      "style",
-      "base",
-      "noscript",
-      "template"
-    ]
   }
 }

--- a/__fixtures__/complex-deno/deno.jsonc
+++ b/__fixtures__/complex-deno/deno.jsonc
@@ -1,0 +1,71 @@
+{
+  "workspace": [
+    "packages/*"
+  ],
+  "nodeModulesDir": "auto",
+  "tasks": {
+    "check": "deno fmt --check . && deno lint . && deno check",
+    "dev": "vite",
+    "build": "vite build",
+    "start": "deno serve -A _fresh/server.js",
+    "update": "deno run -A -r jsr:@fresh/update .",
+    "check-deps": "deno run -A jsr:@check/deps --allow-unused"
+  },
+  "lint": {
+    "rules": {
+      "tags": [
+        "fresh",
+        "recommended"
+      ]
+    }
+  },
+  // "broken:", "this should not be here",
+  "exclude": [
+    "**/_fresh/*"
+  ],
+  "imports": {
+    "@/": "./",
+    "class-variance-authority": "npm:class-variance-authority@^0.7.1",
+    "clsx": "npm:clsx@^2.1.1",
+    "cmdk": "https://esm.sh/cmdk@1.1.1?alias=react:preact/compat&external=preact,@radix-ui/react-dialog&target=es2022",
+    "fresh": "jsr:@fresh/core@^2.0.0-beta.3",
+    "@fresh/plugin-vite": "jsr:@fresh/plugin-vite@^0.9.11",
+    "lucide-preact": "npm:lucide-preact@^0.539.0",
+    "postcss": "npm:postcss@^8.5.6",
+    "preact": "npm:preact@^10.27.1",
+    "@preact/signals": "npm:@preact/signals@^2.3.1",
+    "/*": "TODO: cleanup",
+    "@radix-ui/react-accordion": "https://esm.sh/@radix-ui/react-accordion@1.2.12?alias=react:preact/compat&external=preact,@radix-ui/react-collapsible,@radix-ui/react-collection,@radix-ui/react-compose-refs,@radix-ui/react-context,@radix-ui/react-direction,@radix-ui/react-id,@radix-ui/react-primitive,@radix-ui/react-use-controllable-state&target=es2022",
+    "tailwind-merge": "npm:tailwind-merge@^3.3.1",
+    "tw-animate-css": "npm:tw-animate-css@^1.3.7",
+    "vite": "npm:vite@^7.1.4",
+    "tailwindcss": "npm:tailwindcss@^4.1.12",
+    "@tailwindcss/vite": "npm:@tailwindcss/vite@^4.1.12"
+  },
+  "compilerOptions": {
+    "lib": [
+      "dom",
+      "dom.asynciterable",
+      "dom.iterable",
+      "deno.ns"
+    ],
+    "jsx": "precompile",
+    "jsxImportSource": "preact",
+    "jsxPrecompileSkipElements": [
+      "a",
+      "img",
+      "source",
+      "body",
+      "html",
+      "head",
+      "title",
+      "meta",
+      "script",
+      "link",
+      "style",
+      "base",
+      "noscript",
+      "template"
+    ]
+  }
+}

--- a/__fixtures__/complex-deno/packages/package-one/deno.json
+++ b/__fixtures__/complex-deno/packages/package-one/deno.json
@@ -1,0 +1,5 @@
+{
+  "name": "@scope/package-one",
+  "version": "1.0.0",
+  "exports": "./mod.ts"
+}

--- a/__fixtures__/complex-deno/packages/package-three/deno.jsonc
+++ b/__fixtures__/complex-deno/packages/package-three/deno.jsonc
@@ -1,0 +1,35 @@
+{
+  "name": "@scope/package-three",
+  "version": "1.0.0",
+  "exports": "./mod.ts",
+  // "broken:", "this should not be here",
+  "exclude": [
+    "**/_fresh/*"
+  ],
+  "compilerOptions": {
+    "lib": [
+      "dom",
+      "dom.asynciterable",
+      "dom.iterable",
+      "deno.ns"
+    ],
+    "jsx": "precompile",
+    "jsxImportSource": "preact",
+    "jsxPrecompileSkipElements": [
+      "a",
+      "img",
+      "source",
+      "body",
+      "html",
+      "head",
+      "title",
+      "meta",
+      "script",
+      "link",
+      "style",
+      "base",
+      "noscript",
+      "template"
+    ]
+  }
+}

--- a/__fixtures__/complex-deno/packages/package-two/deno.json
+++ b/__fixtures__/complex-deno/packages/package-two/deno.json
@@ -1,0 +1,21 @@
+{
+  "name": "@scope/package-two",
+  "version": "1.0.0",
+  "exports": "./mod.ts",
+  "tasks": {
+    "check": "deno fmt --check . && deno lint . && deno check",
+    "dev": "vite",
+    "build": "vite build",
+    "start": "deno serve -A _fresh/server.js",
+    "update": "deno run -A -r jsr:@fresh/update .",
+    "check-deps": "deno run -A jsr:@check/deps --allow-unused"
+  },
+  "lint": {
+    "rules": {
+      "tags": [
+        "fresh",
+        "recommended"
+      ]
+    }
+  }
+}

--- a/packages/get-packages/src/index.test.ts
+++ b/packages/get-packages/src/index.test.ts
@@ -246,9 +246,13 @@ let runTests = (getPackages: GetPackages) => {
         return expect(allPackages.packages).not.toBeNull();
       }
 
-      expect(allPackages.packages.map((p) => p.packageJson.name).sort()).toEqual(
-        ["@scope/package-one", "@scope/package-three", "@scope/package-two"]
-      );
+      expect(
+        allPackages.packages.map((p) => p.packageJson.name).sort()
+      ).toEqual([
+        "@scope/package-one",
+        "@scope/package-three",
+        "@scope/package-two",
+      ]);
       expect(allPackages.packages).toHaveLength(3);
       expect(allPackages.tool.type).toEqual("deno");
 
@@ -276,14 +280,18 @@ let runTests = (getPackages: GetPackages) => {
         },
       });
 
-      const packageOne = allPackages.packages.find(p => p.packageJson.name === '@scope/package-one')
+      const packageOne = allPackages.packages.find(
+        (p) => p.packageJson.name === "@scope/package-one"
+      );
       expect(packageOne?.packageJson).toEqual({
         name: "@scope/package-one",
         version: "1.0.0",
         exports: "./mod.ts",
-      })
+      });
 
-      const packageTwo = allPackages.packages.find(p => p.packageJson.name === '@scope/package-two')
+      const packageTwo = allPackages.packages.find(
+        (p) => p.packageJson.name === "@scope/package-two"
+      );
       expect(packageTwo?.packageJson).toEqual({
         name: "@scope/package-two",
         version: "1.0.0",
@@ -303,7 +311,9 @@ let runTests = (getPackages: GetPackages) => {
         },
       });
 
-      const packageThree = allPackages.packages.find(p => p.packageJson.name === '@scope/package-three')
+      const packageThree = allPackages.packages.find(
+        (p) => p.packageJson.name === "@scope/package-three"
+      );
       expect(packageThree?.packageJson).toEqual({
         name: "@scope/package-three",
         version: "1.0.0",

--- a/packages/get-packages/src/index.test.ts
+++ b/packages/get-packages/src/index.test.ts
@@ -234,6 +234,85 @@ let runTests = (getPackages: GetPackages) => {
       expect(allPackages.tool.type).toEqual("deno");
     }
   });
+
+  it("should resolve workspaces for a complex deno project", async () => {
+    const dir = f.copy("complex-deno");
+
+    // Test for both root and subdirectories
+    for (const location of [".", "packages", "packages/package-one"]) {
+      const allPackages = await getPackages(path.join(dir, location));
+
+      if (allPackages.packages === null) {
+        return expect(allPackages.packages).not.toBeNull();
+      }
+
+      expect(allPackages.packages[0].packageJson.name).toEqual(
+        "@scope/package-one"
+      );
+      expect(allPackages.packages).toHaveLength(1);
+      expect(allPackages.tool.type).toEqual("deno");
+
+      expect(allPackages.rootPackage?.packageJson).toEqual({
+        workspace: ["packages/*"],
+        nodeModulesDir: "auto",
+        tasks: {
+          check: "deno fmt --check . && deno lint . && deno check",
+          dev: "vite",
+          build: "vite build",
+          start: "deno serve -A _fresh/server.js",
+          update: "deno run -A -r jsr:@fresh/update .",
+          "check-deps": "deno run -A jsr:@check/deps --allow-unused",
+        },
+        lint: {
+          rules: {
+            tags: ["fresh", "recommended"],
+          },
+        },
+        exclude: ["**/_fresh/*"],
+        imports: {
+          "@/": "./",
+          "class-variance-authority": "npm:class-variance-authority@^0.7.1",
+          clsx: "npm:clsx@^2.1.1",
+          cmdk: "https://esm.sh/cmdk@1.1.1?alias=react:preact/compat&external=preact,@radix-ui/react-dialog&target=es2022",
+          fresh: "jsr:@fresh/core@^2.0.0-beta.3",
+          "@fresh/plugin-vite": "jsr:@fresh/plugin-vite@^0.9.11",
+          "lucide-preact": "npm:lucide-preact@^0.539.0",
+          postcss: "npm:postcss@^8.5.6",
+          preact: "npm:preact@^10.27.1",
+          "@preact/signals": "npm:@preact/signals@^2.3.1",
+          "/*": "TODO: cleanup",
+          "@radix-ui/react-accordion":
+            "https://esm.sh/@radix-ui/react-accordion@1.2.12?alias=react:preact/compat&external=preact,@radix-ui/react-collapsible,@radix-ui/react-collection,@radix-ui/react-compose-refs,@radix-ui/react-context,@radix-ui/react-direction,@radix-ui/react-id,@radix-ui/react-primitive,@radix-ui/react-use-controllable-state&target=es2022",
+          "tailwind-merge": "npm:tailwind-merge@^3.3.1",
+          "tw-animate-css": "npm:tw-animate-css@^1.3.7",
+          vite: "npm:vite@^7.1.4",
+          tailwindcss: "npm:tailwindcss@^4.1.12",
+          "@tailwindcss/vite": "npm:@tailwindcss/vite@^4.1.12",
+        },
+        compilerOptions: {
+          lib: ["dom", "dom.asynciterable", "dom.iterable", "deno.ns"],
+          jsx: "precompile",
+          jsxImportSource: "preact",
+          jsxPrecompileSkipElements: [
+            "a",
+            "img",
+            "source",
+            "body",
+            "html",
+            "head",
+            "title",
+            "meta",
+            "script",
+            "link",
+            "style",
+            "base",
+            "noscript",
+            "template",
+          ],
+        },
+      });
+    }
+  });
 };
 
 describe("getPackages", () => {

--- a/packages/get-packages/src/index.test.ts
+++ b/packages/get-packages/src/index.test.ts
@@ -246,29 +246,14 @@ let runTests = (getPackages: GetPackages) => {
         return expect(allPackages.packages).not.toBeNull();
       }
 
-      expect(allPackages.packages[0].packageJson.name).toEqual(
-        "@scope/package-one"
+      expect(allPackages.packages.map((p) => p.packageJson.name).sort()).toEqual(
+        ["@scope/package-one", "@scope/package-three", "@scope/package-two"]
       );
-      expect(allPackages.packages).toHaveLength(1);
+      expect(allPackages.packages).toHaveLength(3);
       expect(allPackages.tool.type).toEqual("deno");
 
       expect(allPackages.rootPackage?.packageJson).toEqual({
         workspace: ["packages/*"],
-        nodeModulesDir: "auto",
-        tasks: {
-          check: "deno fmt --check . && deno lint . && deno check",
-          dev: "vite",
-          build: "vite build",
-          start: "deno serve -A _fresh/server.js",
-          update: "deno run -A -r jsr:@fresh/update .",
-          "check-deps": "deno run -A jsr:@check/deps --allow-unused",
-        },
-        lint: {
-          rules: {
-            tags: ["fresh", "recommended"],
-          },
-        },
-        exclude: ["**/_fresh/*"],
         imports: {
           "@/": "./",
           "class-variance-authority": "npm:class-variance-authority@^0.7.1",
@@ -289,6 +274,41 @@ let runTests = (getPackages: GetPackages) => {
           tailwindcss: "npm:tailwindcss@^4.1.12",
           "@tailwindcss/vite": "npm:@tailwindcss/vite@^4.1.12",
         },
+      });
+
+      const packageOne = allPackages.packages.find(p => p.packageJson.name === '@scope/package-one')
+      expect(packageOne?.packageJson).toEqual({
+        name: "@scope/package-one",
+        version: "1.0.0",
+        exports: "./mod.ts",
+      })
+
+      const packageTwo = allPackages.packages.find(p => p.packageJson.name === '@scope/package-two')
+      expect(packageTwo?.packageJson).toEqual({
+        name: "@scope/package-two",
+        version: "1.0.0",
+        exports: "./mod.ts",
+        tasks: {
+          check: "deno fmt --check . && deno lint . && deno check",
+          dev: "vite",
+          build: "vite build",
+          start: "deno serve -A _fresh/server.js",
+          update: "deno run -A -r jsr:@fresh/update .",
+          "check-deps": "deno run -A jsr:@check/deps --allow-unused",
+        },
+        lint: {
+          rules: {
+            tags: ["fresh", "recommended"],
+          },
+        },
+      });
+
+      const packageThree = allPackages.packages.find(p => p.packageJson.name === '@scope/package-three')
+      expect(packageThree?.packageJson).toEqual({
+        name: "@scope/package-three",
+        version: "1.0.0",
+        exports: "./mod.ts",
+        exclude: ["**/_fresh/*"],
         compilerOptions: {
           lib: ["dom", "dom.asynciterable", "dom.iterable", "deno.ns"],
           jsx: "precompile",


### PR DESCRIPTION
This commit expands the tests for Deno configuration files (`deno.json` and `deno.jsonc`) to ensure they can handle complex scenarios.

A new test fixture `complex-deno` has been added, which includes a `deno.jsonc` file with:
- Comments
- Complex import aliases (jsr:, npm:, https:)
- Various other Deno-specific properties

The test case verifies that the `getPackages` function correctly parses this complex configuration and that the returned data is valid.