### PR TITLE
chore: reduce redundancy

### DIFF
--- a/packages/tools/src/DenoTool.ts
+++ b/packages/tools/src/DenoTool.ts
@@ -1,6 +1,4 @@
 import path from "node:path";
-import fs from "node:fs";
-import fsp from "node:fs/promises";
 
 import {
   InvalidMonorepoError,
@@ -10,143 +8,58 @@ import {
 } from "./Tool.ts";
 import { expandDenoGlobs, expandDenoGlobsSync } from "./expandDenoGlobs.ts";
 
-import { readJsonc, readJsoncSync } from "./utils.ts";
-
-async function isDenoMonorepoRoot(
-  directory: string,
-  read: (
-    dir: string,
-    file: string
-  ) => Promise<DenoJSON | { workspace?: string[] }>
-): Promise<boolean> {
-  try {
-    let fileName: string | undefined;
-    try {
-      if ((await fsp.stat(path.join(directory, "deno.json"))).isFile()) {
-        fileName = "deno.json";
-      }
-    } catch (err) {
-      if (err && (err as { code: string }).code !== "ENOENT") {
-        throw err;
-      }
-    }
-
-    if (!fileName) {
-      try {
-        if ((await fsp.stat(path.join(directory, "deno.jsonc"))).isFile()) {
-          fileName = "deno.jsonc";
-        }
-      } catch (err) {
-        if (err && (err as { code: string }).code !== "ENOENT") {
-          throw err;
-        }
-      }
-    }
-
-    if (!fileName) return false;
-
-    const pkgJson = await read(directory, fileName);
-    if (pkgJson.workspace) {
-      if (Array.isArray(pkgJson.workspace)) {
-        return true;
-      }
-    }
-  } catch (err) {
-    if (err && (err as { code: string }).code === "ENOENT") {
-      return false;
-    }
-    throw err;
-  }
-  return false;
-}
-
-function isDenoMonorepoRootSync(
-  directory: string,
-  read: (dir: string, file: string) => DenoJSON | { workspace?: string[] }
-): boolean {
-  try {
-    let fileName: string | undefined;
-    try {
-      if (fs.statSync(path.join(directory, "deno.json")).isFile()) {
-        fileName = "deno.json";
-      }
-    } catch (err) {
-      if (err && (err as { code: string }).code !== "ENOENT") {
-        throw err;
-      }
-    }
-
-    if (!fileName) {
-      try {
-        if (fs.statSync(path.join(directory, "deno.jsonc")).isFile()) {
-          fileName = "deno.jsonc";
-        }
-      } catch (err) {
-        if (err && (err as { code: string }).code !== "ENOENT") {
-          throw err;
-        }
-      }
-    }
-
-    if (!fileName) return false;
-
-    const pkgJson = read(directory, fileName);
-    if (pkgJson.workspace) {
-      if (Array.isArray(pkgJson.workspace)) {
-        return true;
-      }
-    }
-  } catch (err) {
-    if (err && (err as { code: string }).code === "ENOENT") {
-      return false;
-    }
-    throw err;
-  }
-  return false;
-}
+import {
+  findDenoConfig,
+  findDenoConfigSync,
+  readJsonc,
+  readJsoncSync,
+} from "./utils.ts";
 
 export const DenoTool: Tool = {
   type: "deno",
 
   async isMonorepoRoot(directory: string): Promise<boolean> {
-    return isDenoMonorepoRoot(directory, readJsonc);
+    try {
+      const fileName = await findDenoConfig(directory);
+      if (!fileName) {
+        return false;
+      }
+      const pkgJson = await readJsonc(directory, fileName);
+      return Array.isArray(pkgJson.workspace);
+    } catch (err) {
+      if (err && (err as { code: string }).code === "ENOENT") {
+        return false;
+      }
+      throw err;
+    }
   },
 
   isMonorepoRootSync(directory: string): boolean {
-    return isDenoMonorepoRootSync(directory, readJsoncSync);
+    try {
+      const fileName = findDenoConfigSync(directory);
+      if (!fileName) {
+        return false;
+      }
+      const pkgJson = readJsoncSync(directory, fileName);
+      return Array.isArray(pkgJson.workspace);
+    } catch (err) {
+      if (err && (err as { code: string }).code === "ENOENT") {
+        return false;
+      }
+      throw err;
+    }
   },
 
   async getPackages(directory: string): Promise<Packages> {
     const rootDir = path.resolve(directory);
 
     try {
-      let fileName: string | undefined;
-      try {
-        if ((await fsp.stat(path.join(directory, "deno.json"))).isFile()) {
-          fileName = "deno.json";
-        }
-      } catch (err) {
-        if (err && (err as { code: string }).code !== "ENOENT") {
-          throw err;
-        }
-      }
-
+      const fileName = await findDenoConfig(directory);
       if (!fileName) {
-        try {
-          if ((await fsp.stat(path.join(directory, "deno.jsonc"))).isFile()) {
-            fileName = "deno.jsonc";
-          }
-        } catch (err) {
-          if (err && (err as { code: string }).code !== "ENOENT") {
-            throw err;
-          }
-        }
-      }
-
-      if (!fileName)
         throw new InvalidMonorepoError(
           `Directory ${rootDir} is not a valid ${DenoTool.type} monorepo root`
         );
+      }
 
       const pkgJson = (await readJsonc(rootDir, fileName)) as DenoJSON;
       const packageGlobs: string[] = pkgJson.workspace!;
@@ -175,33 +88,12 @@ export const DenoTool: Tool = {
     const rootDir = path.resolve(directory);
 
     try {
-      let fileName: string | undefined;
-      try {
-        if (fs.statSync(path.join(directory, "deno.json")).isFile()) {
-          fileName = "deno.json";
-        }
-      } catch (err) {
-        if (err && (err as { code: string }).code !== "ENOENT") {
-          throw err;
-        }
-      }
-
+      const fileName = findDenoConfigSync(directory);
       if (!fileName) {
-        try {
-          if (fs.statSync(path.join(directory, "deno.jsonc")).isFile()) {
-            fileName = "deno.jsonc";
-          }
-        } catch (err) {
-          if (err && (err as { code: string }).code !== "ENOENT") {
-            throw err;
-          }
-        }
-      }
-
-      if (!fileName)
         throw new InvalidMonorepoError(
           `Directory ${rootDir} is not a valid ${DenoTool.type} monorepo root`
         );
+      }
 
       const pkgJson = readJsoncSync(rootDir, fileName) as DenoJSON;
       const packageGlobs: string[] = pkgJson.workspace!;

--- a/packages/tools/src/expandDenoGlobs.ts
+++ b/packages/tools/src/expandDenoGlobs.ts
@@ -1,10 +1,13 @@
 import path from "node:path";
-import fs from "node:fs";
-import fsp from "node:fs/promises";
 import { glob, globSync } from "tinyglobby";
 
 import type { Package, DenoJSON } from "./Tool.ts";
-import { readJsonc, readJsoncSync } from "./utils.ts";
+import {
+  findDenoConfig,
+  findDenoConfigSync,
+  readJsonc,
+  readJsoncSync,
+} from "./utils.ts";
 
 async function getDenoPackageFromDir(
   packageDir: string,
@@ -14,30 +17,10 @@ async function getDenoPackageFromDir(
   const relativeDir = path.relative(rootDir, fullPath);
 
   try {
-    let fileName: string | undefined;
-    try {
-      if ((await fsp.stat(path.join(fullPath, "deno.json"))).isFile()) {
-        fileName = "deno.json";
-      }
-    } catch (err) {
-      if (err && (err as { code: string }).code !== "ENOENT") {
-        throw err;
-      }
-    }
-
+    const fileName = await findDenoConfig(fullPath);
     if (!fileName) {
-      try {
-        if ((await fsp.stat(path.join(fullPath, "deno.jsonc"))).isFile()) {
-          fileName = "deno.jsonc";
-        }
-      } catch (err) {
-        if (err && (err as { code: string }).code !== "ENOENT") {
-          throw err;
-        }
-      }
+      return undefined;
     }
-
-    if (!fileName) return undefined;
 
     const denoJson = (await readJsonc(fullPath, fileName)) as DenoJSON;
 
@@ -65,30 +48,10 @@ function getDenoPackageFromDirSync(
   const relativeDir = path.relative(rootDir, fullPath);
 
   try {
-    let fileName: string | undefined;
-    try {
-      if (fs.statSync(path.join(fullPath, "deno.json")).isFile()) {
-        fileName = "deno.json";
-      }
-    } catch (err) {
-      if (err && (err as { code: string }).code !== "ENOENT") {
-        throw err;
-      }
-    }
-
+    const fileName = findDenoConfigSync(fullPath);
     if (!fileName) {
-      try {
-        if (fs.statSync(path.join(fullPath, "deno.jsonc")).isFile()) {
-          fileName = "deno.jsonc";
-        }
-      } catch (err) {
-        if (err && (err as { code: string }).code !== "ENOENT") {
-          throw err;
-        }
-      }
+      return undefined;
     }
-
-    if (!fileName) return undefined;
 
     const denoJson = readJsoncSync(fullPath, fileName) as DenoJSON;
 

--- a/packages/tools/src/utils.ts
+++ b/packages/tools/src/utils.ts
@@ -14,3 +14,53 @@ export const readJsonc = async (directory: string, file: string) =>
 
 export const readJsoncSync = (directory: string, file: string) =>
   parse(fs.readFileSync(path.join(directory, file), "utf-8"));
+
+export async function findDenoConfig(
+  directory: string
+): Promise<string | undefined> {
+  try {
+    if ((await fsp.stat(path.join(directory, "deno.json"))).isFile()) {
+      return "deno.json";
+    }
+  } catch (err) {
+    if (err && (err as { code: string }).code !== "ENOENT") {
+      throw err;
+    }
+  }
+
+  try {
+    if ((await fsp.stat(path.join(directory, "deno.jsonc"))).isFile()) {
+      return "deno.jsonc";
+    }
+  } catch (err) {
+    if (err && (err as { code: string }).code !== "ENOENT") {
+      throw err;
+    }
+  }
+
+  return undefined;
+}
+
+export function findDenoConfigSync(directory: string): string | undefined {
+  try {
+    if (fs.statSync(path.join(directory, "deno.json")).isFile()) {
+      return "deno.json";
+    }
+  } catch (err) {
+    if (err && (err as { code: string }).code !== "ENOENT") {
+      throw err;
+    }
+  }
+
+  try {
+    if (fs.statSync(path.join(directory, "deno.jsonc")).isFile()) {
+      return "deno.jsonc";
+    }
+  } catch (err) {
+    if (err && (err as { code: string }).code !== "ENOENT") {
+      throw err;
+    }
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
The DenoTool and expandDenoGlobs files contained redundant logic for finding `deno.json` and `deno.jsonc` files. This change abstracts this logic into new `findDenoConfig` and `findDenoConfigSync` helper functions in `utils.ts`.

The following files were updated to use the new helper functions:
- `packages/tools/src/DenoTool.ts`
- `packages/tools/src/expandDenoGlobs.ts`

This refactoring simplifies the code and makes it more maintainable without changing the functionality. All tests pass after the changes.