### PR TITLE
refactor: use package-based imports for cross-package references

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "@changesets/types": "^6.1.0",
+    "@manypkg/tools": "workspace:^",
     "@types/validate-npm-package-name": "^4.0.2",
     "fixturez": "^1.1.0",
     "strip-ansi": "^7.1.0",

--- a/packages/cli/src/checks/EXTERNAL_MISMATCH.ts
+++ b/packages/cli/src/checks/EXTERNAL_MISMATCH.ts
@@ -5,7 +5,7 @@ import {
 } from "./utils.ts";
 import type { Package } from "@manypkg/get-packages";
 import { validRange } from "semver";
-import type { DenoJSON } from "../../../tools/src/index.ts";
+import type { DenoJSON } from "@manypkg/tools";
 
 type ErrorType = {
   type: "EXTERNAL_MISMATCH";

--- a/packages/cli/src/checks/EXTERNAL_MISMATCH.ts
+++ b/packages/cli/src/checks/EXTERNAL_MISMATCH.ts
@@ -5,7 +5,7 @@ import {
 } from "./utils.ts";
 import type { Package } from "@manypkg/get-packages";
 import { validRange } from "semver";
-import { isDenoPackage, type DenoJSON } from "@manypkg/tools";
+import { isDenoPackage, isNodePackage, type DenoJSON } from "@manypkg/tools";
 
 type ErrorType = {
   type: "EXTERNAL_MISMATCH";
@@ -44,7 +44,7 @@ export default makeCheck<ErrorType>({
           }
         }
       }
-    } else {
+    } else if (isNodePackage(workspace)) {
       for (let depType of NORMAL_DEPENDENCY_TYPES) {
         let deps = workspace.packageJson[depType];
 
@@ -84,7 +84,7 @@ export default makeCheck<ErrorType>({
           }
         }
       }
-    } else {
+    } else if (isNodePackage(error.workspace)) {
       for (let depType of NORMAL_DEPENDENCY_TYPES) {
         let deps = error.workspace.packageJson[depType];
         if (deps && deps[error.dependencyName]) {

--- a/packages/cli/src/checks/INTERNAL_MISMATCH.ts
+++ b/packages/cli/src/checks/INTERNAL_MISMATCH.ts
@@ -6,7 +6,7 @@ import {
 import semver from "semver";
 import type { Package } from "@manypkg/get-packages";
 import type { a } from "vitest/dist/chunks/suite.d.FvehnV49.js";
-import { isDenoPackage, type DenoJSON } from "@manypkg/tools";
+import { isDenoPackage, isNodePackage, type DenoJSON } from "@manypkg/tools";
 
 export type ErrorType = {
   type: "INTERNAL_MISMATCH";
@@ -39,7 +39,7 @@ export default makeCheck<ErrorType>({
           }
         }
       }
-    } else {
+    } else if (isNodePackage(workspace)) {
       for (let depType of NORMAL_DEPENDENCY_TYPES) {
         let deps = workspace.packageJson[depType];
         if (deps) {
@@ -83,7 +83,7 @@ export default makeCheck<ErrorType>({
           }
         }
       }
-    } else {
+    } else if (isNodePackage(error.workspace)) {
       for (let depType of NORMAL_DEPENDENCY_TYPES) {
         let deps = error.workspace.packageJson[depType];
         if (deps && deps[error.dependencyWorkspace.packageJson.name]) {

--- a/packages/cli/src/checks/INTERNAL_MISMATCH.ts
+++ b/packages/cli/src/checks/INTERNAL_MISMATCH.ts
@@ -6,7 +6,7 @@ import {
 import semver from "semver";
 import type { Package } from "@manypkg/get-packages";
 import type { a } from "vitest/dist/chunks/suite.d.FvehnV49.js";
-import type { DenoJSON } from "../../../tools/src/index.ts";
+import type { DenoJSON } from "@manypkg/tools";
 
 export type ErrorType = {
   type: "INTERNAL_MISMATCH";

--- a/packages/cli/src/checks/MULTIPLE_DEPENDENCY_TYPES.ts
+++ b/packages/cli/src/checks/MULTIPLE_DEPENDENCY_TYPES.ts
@@ -1,4 +1,5 @@
 import { makeCheck } from "./utils.ts";
+import { isNodePackage } from "@manypkg/tools";
 import type { Package } from "@manypkg/get-packages";
 
 type ErrorType = {
@@ -10,37 +11,44 @@ type ErrorType = {
 
 export default makeCheck<ErrorType>({
   validate: (workspace, allWorkspaces) => {
-    let dependencies = new Set<string>();
-    let errors: ErrorType[] = [];
-    if (workspace.packageJson.dependencies) {
-      for (let depName in workspace.packageJson.dependencies) {
-        dependencies.add(depName);
+    if (isNodePackage(workspace)) {
+      let dependencies = new Set<string>();
+      let errors: ErrorType[] = [];
+      if (workspace.packageJson.dependencies) {
+        for (let depName in workspace.packageJson.dependencies) {
+          dependencies.add(depName);
+        }
       }
-    }
-    for (let depType of ["devDependencies", "optionalDependencies"] as const) {
-      let deps = workspace.packageJson[depType];
-      if (deps) {
-        for (let depName in deps) {
-          if (dependencies.has(depName)) {
-            errors.push({
-              type: "MULTIPLE_DEPENDENCY_TYPES",
-              dependencyType: depType,
-              dependencyName: depName,
-              workspace,
-            });
+      for (
+        let depType of ["devDependencies", "optionalDependencies"] as const
+      ) {
+        let deps = workspace.packageJson[depType];
+        if (deps) {
+          for (let depName in deps) {
+            if (dependencies.has(depName)) {
+              errors.push({
+                type: "MULTIPLE_DEPENDENCY_TYPES",
+                dependencyType: depType,
+                dependencyName: depName,
+                workspace,
+              });
+            }
           }
         }
       }
+      return errors;
     }
-    return errors;
+    return [];
   },
   type: "all",
   fix: (error) => {
-    let deps = error.workspace.packageJson[error.dependencyType];
-    if (deps) {
-      delete deps[error.dependencyName];
-      if (Object.keys(deps).length === 0) {
-        delete error.workspace.packageJson[error.dependencyType];
+    if (isNodePackage(error.workspace)) {
+      let deps = error.workspace.packageJson[error.dependencyType];
+      if (deps) {
+        delete deps[error.dependencyName];
+        if (Object.keys(deps).length === 0) {
+          delete error.workspace.packageJson[error.dependencyType];
+        }
       }
     }
     return { requiresInstall: true };

--- a/packages/cli/src/checks/UNSORTED_DEPENDENCIES.ts
+++ b/packages/cli/src/checks/UNSORTED_DEPENDENCIES.ts
@@ -1,4 +1,4 @@
-import { isDenoPackage, type DenoJSON } from "@manypkg/tools";
+import { isDenoPackage, isNodePackage, type DenoJSON } from "@manypkg/tools";
 import {
   makeCheck,
   DEPENDENCY_TYPES,
@@ -28,7 +28,7 @@ export default makeCheck<ErrorType>({
           },
         ];
       }
-    } else {
+    } else if (isNodePackage(workspace)) {
       for (let depType of DEPENDENCY_TYPES) {
         let deps = workspace.packageJson[depType];
         if (

--- a/packages/cli/src/checks/UNSORTED_DEPENDENCIES.ts
+++ b/packages/cli/src/checks/UNSORTED_DEPENDENCIES.ts
@@ -1,4 +1,4 @@
-import type { DenoJSON } from "@manypkg/tools";
+import { isDenoPackage, type DenoJSON } from "@manypkg/tools";
 import {
   makeCheck,
   DEPENDENCY_TYPES,
@@ -15,20 +15,18 @@ type ErrorType = {
 export default makeCheck<ErrorType>({
   type: "all",
   validate: (workspace) => {
-    if (workspace.tool.type === "deno") {
-      if ((workspace.packageJson as DenoJSON).imports) {
-        let deps = (workspace.packageJson as DenoJSON).imports;
-        if (
-          deps &&
-          !isArrayEqual(Object.keys(deps), Object.keys(deps).sort())
-        ) {
-          return [
-            {
-              type: "UNSORTED_DEPENDENCIES",
-              workspace,
-            },
-          ];
-        }
+    if (isDenoPackage(workspace)) {
+      const deps = workspace.packageJson.imports;
+      if (
+        deps &&
+        !isArrayEqual(Object.keys(deps), Object.keys(deps).sort())
+      ) {
+        return [
+          {
+            type: "UNSORTED_DEPENDENCIES",
+            workspace,
+          },
+        ];
       }
     } else {
       for (let depType of DEPENDENCY_TYPES) {

--- a/packages/cli/src/checks/UNSORTED_DEPENDENCIES.ts
+++ b/packages/cli/src/checks/UNSORTED_DEPENDENCIES.ts
@@ -1,4 +1,4 @@
-import type { DenoJSON } from "../../../tools/src/index.ts";
+import type { DenoJSON } from "@manypkg/tools";
 import {
   makeCheck,
   DEPENDENCY_TYPES,

--- a/packages/cli/src/checks/__tests__/EXTERNAL_MISMATCH_deno.test.ts
+++ b/packages/cli/src/checks/__tests__/EXTERNAL_MISMATCH_deno.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect } from "vitest";
 import fixturez from "fixturez";
 import check from "../EXTERNAL_MISMATCH.ts";
 import { getPackages } from "@manypkg/get-packages";
-import type { DenoJSON } from "../../../../tools/src/Tool.ts";
+import type { DenoJSON } from "@manypkg/tools";
 
 const f = fixturez(__dirname);
 

--- a/packages/cli/src/checks/__tests__/EXTERNAL_MISMATCH_deno.test.ts
+++ b/packages/cli/src/checks/__tests__/EXTERNAL_MISMATCH_deno.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect } from "vitest";
 import fixturez from "fixturez";
 import check from "../EXTERNAL_MISMATCH.ts";
 import { getPackages } from "@manypkg/get-packages";
-import type { DenoJSON } from "@manypkg/tools";
+import { isDenoPackage, type DenoJSON } from "@manypkg/tools";
 
 const f = fixturez(__dirname);
 
@@ -42,10 +42,11 @@ describe("deno external mismatch", () => {
 
     check.fix!(error, {});
 
-    const imports = (pkgTwo.packageJson as DenoJSON).imports as Record<
-      string,
-      string
-    >;
-    expect(imports["@oak/oak"]).toBe("jsr:@oak/oak@^14.2.0");
+    if (isDenoPackage(pkgTwo)) {
+      const imports = pkgTwo.packageJson.imports;
+      if (imports) {
+        expect(imports["@oak/oak"]).toBe("jsr:@oak/oak@^14.2.0");
+      }
+    }
   });
 });

--- a/packages/cli/src/checks/__tests__/INTERNAL_MISMATCH_deno.test.ts
+++ b/packages/cli/src/checks/__tests__/INTERNAL_MISMATCH_deno.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect } from "vitest";
 import fixturez from "fixturez";
 import check from "../INTERNAL_MISMATCH.ts";
 import { getPackages } from "@manypkg/get-packages";
-import type { DenoJSON } from "@manypkg/tools";
+import { isDenoPackage, type DenoJSON } from "@manypkg/tools";
 
 const f = fixturez(__dirname);
 
@@ -42,10 +42,13 @@ describe("deno internal mismatch", () => {
 
     check.fix!(error, {});
 
-    const imports = (pkgOne.packageJson as DenoJSON).imports as Record<
-      string,
-      string
-    >;
-    expect(imports["@scope/package-two"]).toBe("jsr:@scope/package-two@^1.0.0");
+    if (isDenoPackage(pkgOne)) {
+      const imports = pkgOne.packageJson.imports;
+      if (imports) {
+        expect(imports["@scope/package-two"]).toBe(
+          "jsr:@scope/package-two@^1.0.0"
+        );
+      }
+    }
   });
 });

--- a/packages/cli/src/checks/__tests__/INTERNAL_MISMATCH_deno.test.ts
+++ b/packages/cli/src/checks/__tests__/INTERNAL_MISMATCH_deno.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect } from "vitest";
 import fixturez from "fixturez";
 import check from "../INTERNAL_MISMATCH.ts";
 import { getPackages } from "@manypkg/get-packages";
-import type { DenoJSON } from "../../../../tools/src/index.ts";
+import type { DenoJSON } from "@manypkg/tools";
 
 const f = fixturez(__dirname);
 

--- a/packages/cli/src/checks/__tests__/UNSORTED_DEPENDENCIES_deno.test.ts
+++ b/packages/cli/src/checks/__tests__/UNSORTED_DEPENDENCIES_deno.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect } from "vitest";
 import fixturez from "fixturez";
 import check from "../UNSORTED_DEPENDENCIES.ts";
 import { getPackages } from "@manypkg/get-packages";
-import type { DenoJSON } from "@manypkg/tools";
+import { isDenoPackage, type DenoJSON } from "@manypkg/tools";
 
 const f = fixturez(__dirname);
 
@@ -38,10 +38,11 @@ describe("deno unsorted dependencies", () => {
 
     check.fix!(error, {});
 
-    const imports = (pkgOne.packageJson as DenoJSON).imports as Record<
-      string,
-      string
-    >;
-    expect(Object.keys(imports)).toEqual(["oak", "zod"]);
+    if (isDenoPackage(pkgOne)) {
+      const imports = pkgOne.packageJson.imports;
+      if (imports) {
+        expect(Object.keys(imports)).toEqual(["oak", "zod"]);
+      }
+    }
   });
 });

--- a/packages/cli/src/checks/__tests__/UNSORTED_DEPENDENCIES_deno.test.ts
+++ b/packages/cli/src/checks/__tests__/UNSORTED_DEPENDENCIES_deno.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect } from "vitest";
 import fixturez from "fixturez";
 import check from "../UNSORTED_DEPENDENCIES.ts";
 import { getPackages } from "@manypkg/get-packages";
-import type { DenoJSON } from "../../../../tools/src/index.ts";
+import type { DenoJSON } from "@manypkg/tools";
 
 const f = fixturez(__dirname);
 

--- a/packages/cli/src/checks/__tests__/test-helpers.ts
+++ b/packages/cli/src/checks/__tests__/test-helpers.ts
@@ -1,7 +1,8 @@
 import type { Package } from "@manypkg/get-packages";
+import type { PackageJSON } from "@manypkg/tools";
 import crypto from "node:crypto";
 
-export let getRootWS = (): Package => {
+export let getRootWS = (): Package & { packageJson: PackageJSON } => {
   return {
     dir: `fake/monorepo`,
     relativeDir: ".",
@@ -17,7 +18,7 @@ export let getRootWS = (): Package => {
 export let getFakeWS = (
   name: string = "pkg-1",
   version: string = "1.0.0"
-): Package => {
+): Package & { packageJson: PackageJSON } => {
   return {
     dir: `fake/monorepo/packages/${name}`,
     relativeDir: `packages/${name}`,
@@ -29,7 +30,10 @@ export let getFakeWS = (
   };
 };
 
-export let getWS = (): Map<string, Package> => {
+export let getWS = (): Map<
+  string,
+  Package & { packageJson: PackageJSON }
+> => {
   let pkg = new Map();
   pkg.set("pkg-1", getFakeWS());
   return pkg;

--- a/packages/cli/src/checks/utils.ts
+++ b/packages/cli/src/checks/utils.ts
@@ -1,7 +1,7 @@
 import type { Package } from "@manypkg/get-packages";
 import * as semver from "semver";
 import { highest } from "sembear";
-import { isDenoPackage, type DenoJSON } from "@manypkg/tools";
+import { isDenoPackage, isNodePackage, type DenoJSON } from "@manypkg/tools";
 
 export const NORMAL_DEPENDENCY_TYPES = [
   "dependencies",
@@ -96,10 +96,12 @@ export function sortDeps(pkg: Package) {
     }
     return;
   }
-  for (let depType of DEPENDENCY_TYPES) {
-    let prevDeps = pkg.packageJson[depType];
-    if (prevDeps) {
-      pkg.packageJson[depType] = sortObject(prevDeps);
+  if (isNodePackage(pkg)) {
+    for (let depType of DEPENDENCY_TYPES) {
+      let prevDeps = pkg.packageJson[depType];
+      if (prevDeps) {
+        pkg.packageJson[depType] = sortObject(prevDeps);
+      }
     }
   }
 }
@@ -137,7 +139,7 @@ export let getMostCommonRangeMap = weakMemoize(function getMostCommonRanges(
           }
         }
       }
-    } else {
+    } else if (isNodePackage(pkg)) {
       for (let depType of NORMAL_DEPENDENCY_TYPES) {
         let deps = pkg.packageJson[depType];
         if (deps) {

--- a/packages/cli/src/checks/utils.ts
+++ b/packages/cli/src/checks/utils.ts
@@ -1,7 +1,7 @@
 import type { Package } from "@manypkg/get-packages";
 import * as semver from "semver";
 import { highest } from "sembear";
-import type { DenoJSON } from "@manypkg/tools";
+import { isDenoPackage, type DenoJSON } from "@manypkg/tools";
 
 export const NORMAL_DEPENDENCY_TYPES = [
   "dependencies",
@@ -90,11 +90,9 @@ export function sortObject(prevObj: { [key: string]: string }) {
 }
 
 export function sortDeps(pkg: Package) {
-  if (pkg.tool.type === "deno") {
-    if ((pkg.packageJson as DenoJSON).imports) {
-      (pkg.packageJson as DenoJSON).imports = sortObject(
-        (pkg.packageJson as DenoJSON).imports || {}
-      );
+  if (isDenoPackage(pkg)) {
+    if (pkg.packageJson.imports) {
+      pkg.packageJson.imports = sortObject(pkg.packageJson.imports || {});
     }
     return;
   }
@@ -124,7 +122,7 @@ export let getMostCommonRangeMap = weakMemoize(function getMostCommonRanges(
   let dependencyRangesMapping = new Map<string, { [key: string]: number }>();
 
   for (let [pkgName, pkg] of allPackages) {
-    if (pkg.tool.type === "deno") {
+    if (isDenoPackage(pkg)) {
       if (pkg.dependencies) {
         for (let depName in pkg.dependencies) {
           const dep = pkg.dependencies[depName];

--- a/packages/cli/src/checks/utils.ts
+++ b/packages/cli/src/checks/utils.ts
@@ -1,7 +1,7 @@
 import type { Package } from "@manypkg/get-packages";
 import * as semver from "semver";
 import { highest } from "sembear";
-import type { DenoJSON } from "../../../tools/src/Tool.ts";
+import type { DenoJSON } from "@manypkg/tools";
 
 export const NORMAL_DEPENDENCY_TYPES = [
   "dependencies",

--- a/packages/cli/src/npm-tag.ts
+++ b/packages/cli/src/npm-tag.ts
@@ -1,4 +1,5 @@
 import { getPackages } from "@manypkg/get-packages";
+import { isNodePackage } from "@manypkg/tools";
 import type { PackageJSON } from "@changesets/types";
 import { exec } from "tinyexec";
 import pLimit from "p-limit";
@@ -52,6 +53,7 @@ export async function npmTagAll([tag, _, otp]: string[]) {
   let { packages } = await getPackages(process.cwd());
   await Promise.all(
     packages
+      .filter(isNodePackage)
       .filter(({ packageJson }) => packageJson.private !== true)
       .map(({ packageJson }) =>
         npmLimit(() => tagApackage(packageJson, tag, otp))

--- a/packages/tools/src/DenoTool.ts
+++ b/packages/tools/src/DenoTool.ts
@@ -75,6 +75,12 @@ function extractDependencies(json: DenoJSON): Package["dependencies"] {
   return dependencies;
 }
 
+export function isDenoPackage(
+  pkg: Package
+): pkg is Package & { packageJson: DenoJSON } {
+  return pkg.tool.type === "deno";
+}
+
 export const DenoTool: Tool = {
   type: "deno",
 

--- a/packages/tools/src/DenoTool.ts
+++ b/packages/tools/src/DenoTool.ts
@@ -75,12 +75,6 @@ function extractDependencies(json: DenoJSON): Package["dependencies"] {
   return dependencies;
 }
 
-export function isDenoPackage(
-  pkg: Package
-): pkg is Package & { packageJson: DenoJSON } {
-  return pkg.tool.type === "deno";
-}
-
 export const DenoTool: Tool = {
   type: "deno",
 

--- a/packages/tools/src/DenoTool.ts
+++ b/packages/tools/src/DenoTool.ts
@@ -1,8 +1,46 @@
 import path from "node:path";
 
+/**
+ * An in-memory representation of a deno.json[c] file.
+ */
+export interface DenoJSON {
+  compilerOptions?: Record<string, unknown>;
+  lint?: {
+    include?: string[];
+    exclude?: string[];
+    rules?: {
+      tags?: string[];
+      include?: string[];
+      exclude?: string[];
+    };
+  };
+  fmt?: {
+    useTabs?: boolean;
+    lineWidth?: number;
+    indentWidth?: number;
+    semiColons?: boolean;
+    singleQuote?: boolean;
+    proseWrap?: string;
+    include?: string[];
+    exclude?: string[];
+  };
+  lock?: boolean | string;
+  nodeModulesDir?: "auto" | string;
+  unstable?: string[];
+  test?: {
+    include?: string[];
+    exclude?: string[];
+  };
+  tasks?: Record<string, string>;
+  imports?: Record<string, string>;
+  exclude?: string[];
+  workspace?: string[];
+  name: string;
+  version: string;
+}
+
 import {
   InvalidMonorepoError,
-  type DenoJSON,
   type Package,
   type Packages,
   type Tool,

--- a/packages/tools/src/Tool.ts
+++ b/packages/tools/src/Tool.ts
@@ -34,11 +34,13 @@ export type PackageJSON = {
  * An individual package json structure, along with the directory it lives in,
  * relative to the root of the current monorepo.
  */
+import type { DenoJSON } from "./DenoTool.ts";
+
 export interface Package {
   /**
    * The pre-loaded package json structure.
    */
-  packageJson: PackageJSON; // TODO: may also be DenoJSON
+  packageJson: PackageJSON | DenoJSON;
   dependencies?: Record<
     string,
     {

--- a/packages/tools/src/Tool.ts
+++ b/packages/tools/src/Tool.ts
@@ -135,6 +135,18 @@ export type ToolType =
  * Each tool defines a common interface for detecting whether a directory is
  * a valid instance of this type of monorepo, how to retrieve the packages, etc.
  */
+export function isDenoPackage(
+  pkg: Package
+): pkg is Package & { packageJson: DenoJSON } {
+  return pkg.tool.type === "deno";
+}
+
+export function isNodePackage(
+  pkg: Package
+): pkg is Package & { packageJson: PackageJSON } {
+  return pkg.tool.type !== "deno";
+}
+
 export interface Tool {
   /**
    * A string identifier for this monorepo tool. Should be unique among monorepo tools

--- a/packages/tools/src/Tool.ts
+++ b/packages/tools/src/Tool.ts
@@ -31,45 +31,6 @@ export type PackageJSON = {
 };
 
 /**
- * An in-memory representation of a deno.json[c] file.
- */
-export interface DenoJSON {
-  compilerOptions?: Record<string, unknown>;
-  lint?: {
-    include?: string[];
-    exclude?: string[];
-    rules?: {
-      tags?: string[];
-      include?: string[];
-      exclude?: string[];
-    };
-  };
-  fmt?: {
-    useTabs?: boolean;
-    lineWidth?: number;
-    indentWidth?: number;
-    semiColons?: boolean;
-    singleQuote?: boolean;
-    proseWrap?: string;
-    include?: string[];
-    exclude?: string[];
-  };
-  lock?: boolean | string;
-  nodeModulesDir?: "auto" | string;
-  unstable?: string[];
-  test?: {
-    include?: string[];
-    exclude?: string[];
-  };
-  tasks?: Record<string, string>;
-  imports?: Record<string, string>;
-  exclude?: string[];
-  workspace?: string[];
-  name: string;
-  version: string;
-}
-
-/**
  * An individual package json structure, along with the directory it lives in,
  * relative to the root of the current monorepo.
  */

--- a/packages/tools/src/expandDenoGlobs.ts
+++ b/packages/tools/src/expandDenoGlobs.ts
@@ -1,7 +1,8 @@
 import path from "node:path";
 import { glob, globSync } from "tinyglobby";
 
-import type { Package, DenoJSON, Tool } from "./Tool.ts";
+import type { Package, Tool } from "./Tool.ts";
+import type { DenoJSON } from "./DenoTool.ts";
 
 const dependencyRegexp =
   /^(?<protocol>jsr:|npm:|https:|http:)\/?(?<name>@?[^@\s]+)@?(?<version>[^\s/]+)?\/?/;

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -7,3 +7,4 @@ export { PnpmTool } from "./PnpmTool.ts";
 export { RootTool } from "./RootTool.ts";
 export { RushTool } from "./RushTool.ts";
 export { YarnTool } from "./YarnTool.ts";
+export type { DenoJSON } from "./DenoTool.ts";

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -7,4 +7,4 @@ export { PnpmTool } from "./PnpmTool.ts";
 export { RootTool } from "./RootTool.ts";
 export { RushTool } from "./RushTool.ts";
 export { YarnTool } from "./YarnTool.ts";
-export type { DenoJSON } from "./DenoTool.ts";
+export { isDenoPackage, type DenoJSON } from "./DenoTool.ts";

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -7,4 +7,5 @@ export { PnpmTool } from "./PnpmTool.ts";
 export { RootTool } from "./RootTool.ts";
 export { RushTool } from "./RushTool.ts";
 export { YarnTool } from "./YarnTool.ts";
-export { isDenoPackage, type DenoJSON } from "./DenoTool.ts";
+export { type DenoJSON } from "./DenoTool.ts";
+export { isDenoPackage, isNodePackage } from "./Tool.ts";


### PR DESCRIPTION
Moves the DenoJSON type from the tools package to a separate file and exports it from the package's entry point. This allows other packages to import the type using a package-based import instead of a relative path.

This change also adds the @manypkg/tools package as a devDependency to the @manypkg/cli package and updates the import statement in the corresponding test file.