### PR TITLE
Refactor: Use generic Package<T> type to improve type safety

### DIFF
--- a/packages/cli/src/checks/EXTERNAL_MISMATCH.ts
+++ b/packages/cli/src/checks/EXTERNAL_MISMATCH.ts
@@ -12,7 +12,7 @@ const dependencyRegexp =
 
 type ErrorType = {
   type: "EXTERNAL_MISMATCH";
-  workspace: Package;
+  workspace: Package<any>;
   dependencyName: string;
   dependencyRange: string;
   mostCommonDependencyRange: string;

--- a/packages/cli/src/checks/INCORRECT_REPOSITORY_FIELD.ts
+++ b/packages/cli/src/checks/INCORRECT_REPOSITORY_FIELD.ts
@@ -1,12 +1,14 @@
 import parseGithubUrl from "parse-github-url";
 import normalizePath from "normalize-path";
 import type { Package } from "@manypkg/get-packages";
+import type { PackageJSON } from "@manypkg/tools";
 
+import { isNodePackage } from "@manypkg/tools";
 import { makeCheck } from "./utils.ts";
 
 type ErrorType = {
   type: "INCORRECT_REPOSITORY_FIELD";
-  workspace: Package;
+  workspace: Package<PackageJSON>;
   currentRepositoryField: string | undefined;
   correctRepositoryField: string;
 };
@@ -14,58 +16,62 @@ type ErrorType = {
 export default makeCheck<ErrorType>({
   type: "all",
   validate: (workspace, allWorkspaces, rootWorkspace, options) => {
-    let rootRepositoryField: unknown = (rootWorkspace?.packageJson as any)
-      ?.repository;
+    if (
+      isNodePackage(workspace) &&
+      rootWorkspace &&
+      isNodePackage(rootWorkspace)
+    ) {
+      let rootRepositoryField: unknown = rootWorkspace.packageJson.repository;
 
-    if (typeof rootRepositoryField === "string") {
-      let result = parseGithubUrl(rootRepositoryField);
-      if (
-        result !== null &&
-        (result.host === "github.com" || result.host === "dev.azure.com")
-      ) {
-        let baseRepositoryUrl = "";
-        if (result.host === "github.com") {
-          baseRepositoryUrl = `${result.protocol}//${result.host}/${result.owner}/${result.name}`;
-        } else if (result.host === "dev.azure.com") {
-          baseRepositoryUrl = `${result.protocol}//${result.host}/${result.owner}/${result.name}/_git/${result.filepath}`;
-        }
-
-        if (workspace === rootWorkspace) {
-          let correctRepositoryField = baseRepositoryUrl;
-          if (rootRepositoryField !== correctRepositoryField) {
-            return [
-              {
-                type: "INCORRECT_REPOSITORY_FIELD",
-                workspace,
-                currentRepositoryField: rootRepositoryField,
-                correctRepositoryField,
-              },
-            ];
-          }
-        } else {
-          let correctRepositoryField = "";
-
+      if (typeof rootRepositoryField === "string") {
+        let result = parseGithubUrl(rootRepositoryField);
+        if (
+          result !== null &&
+          (result.host === "github.com" || result.host === "dev.azure.com")
+        ) {
+          let baseRepositoryUrl = "";
           if (result.host === "github.com") {
-            correctRepositoryField = `${baseRepositoryUrl}/tree/${
-              options.defaultBranch
-            }/${normalizePath(workspace.relativeDir)}`;
+            baseRepositoryUrl = `${result.protocol}//${result.host}/${result.owner}/${result.name}`;
           } else if (result.host === "dev.azure.com") {
-            correctRepositoryField = `${baseRepositoryUrl}?path=${normalizePath(
-              workspace.relativeDir
-            )}&version=GB${options.defaultBranch}&_a=contents`;
+            baseRepositoryUrl = `${result.protocol}//${result.host}/${result.owner}/${result.name}/_git/${result.filepath}`;
           }
 
-          let currentRepositoryField = (workspace.packageJson as any)
-            .repository;
-          if (correctRepositoryField !== currentRepositoryField) {
-            return [
-              {
-                type: "INCORRECT_REPOSITORY_FIELD",
-                workspace,
-                currentRepositoryField,
-                correctRepositoryField,
-              },
-            ];
+          if (workspace === rootWorkspace) {
+            let correctRepositoryField = baseRepositoryUrl;
+            if (rootRepositoryField !== correctRepositoryField) {
+              return [
+                {
+                  type: "INCORRECT_REPOSITORY_FIELD",
+                  workspace,
+                  currentRepositoryField: rootRepositoryField as string,
+                  correctRepositoryField,
+                },
+              ];
+            }
+          } else {
+            let correctRepositoryField = "";
+
+            if (result.host === "github.com") {
+              correctRepositoryField = `${baseRepositoryUrl}/tree/${
+                options.defaultBranch
+              }/${normalizePath(workspace.relativeDir)}`;
+            } else if (result.host === "dev.azure.com") {
+              correctRepositoryField = `${baseRepositoryUrl}?path=${normalizePath(
+                workspace.relativeDir
+              )}&version=GB${options.defaultBranch}&_a=contents`;
+            }
+
+            let currentRepositoryField = workspace.packageJson.repository;
+            if (correctRepositoryField !== currentRepositoryField) {
+              return [
+                {
+                  type: "INCORRECT_REPOSITORY_FIELD",
+                  workspace,
+                  currentRepositoryField,
+                  correctRepositoryField,
+                },
+              ];
+            }
           }
         }
       }
@@ -73,8 +79,9 @@ export default makeCheck<ErrorType>({
     return [];
   },
   fix: (error: ErrorType) => {
-    (error.workspace.packageJson as any).repository =
-      error.correctRepositoryField;
+    if (isNodePackage(error.workspace)) {
+      error.workspace.packageJson.repository = error.correctRepositoryField;
+    }
   },
   print: (error) => {
     if (error.currentRepositoryField === undefined) {

--- a/packages/cli/src/checks/INCORRECT_REPOSITORY_FIELD.ts
+++ b/packages/cli/src/checks/INCORRECT_REPOSITORY_FIELD.ts
@@ -15,7 +15,7 @@ type ErrorType = {
 
 export default makeCheck<ErrorType>({
   type: "all",
-  validate: (workspace, allWorkspaces, rootWorkspace, options) => {
+  validate: (workspace, _allWorkspaces, rootWorkspace, options) => {
     if (
       isNodePackage(workspace) &&
       rootWorkspace &&

--- a/packages/cli/src/checks/INTERNAL_MISMATCH.ts
+++ b/packages/cli/src/checks/INTERNAL_MISMATCH.ts
@@ -12,8 +12,8 @@ const dependencyRegexp =
 
 export type ErrorType = {
   type: "INTERNAL_MISMATCH";
-  workspace: Package;
-  dependencyWorkspace: Package;
+  workspace: Package<any>;
+  dependencyWorkspace: Package<any>;
   dependencyRange: string;
   dependencyAlias?: string;
 };

--- a/packages/cli/src/checks/INVALID_DEV_AND_PEER_DEPENDENCY_RELATIONSHIP.ts
+++ b/packages/cli/src/checks/INVALID_DEV_AND_PEER_DEPENDENCY_RELATIONSHIP.ts
@@ -1,12 +1,13 @@
 import { makeCheck, getMostCommonRangeMap } from "./utils.ts";
 import { isNodePackage } from "@manypkg/tools";
 import type { Package } from "@manypkg/get-packages";
+import type { PackageJSON } from "@manypkg/tools";
 import { upperBoundOfRangeAWithinBoundsOfB } from "sembear";
 import semver from "semver";
 
 type ErrorType = {
   type: "INVALID_DEV_AND_PEER_DEPENDENCY_RELATIONSHIP";
-  workspace: Package;
+  workspace: Package<PackageJSON>;
   peerVersion: string;
   dependencyName: string;
   devVersion: string | null;

--- a/packages/cli/src/checks/INVALID_PACKAGE_NAME.ts
+++ b/packages/cli/src/checks/INVALID_PACKAGE_NAME.ts
@@ -4,7 +4,7 @@ import validateNpmPackageName from "validate-npm-package-name";
 
 type ErrorType = {
   type: "INVALID_PACKAGE_NAME";
-  workspace: Package;
+  workspace: Package<any>;
   errors: string[];
 };
 

--- a/packages/cli/src/checks/MULTIPLE_DEPENDENCY_TYPES.ts
+++ b/packages/cli/src/checks/MULTIPLE_DEPENDENCY_TYPES.ts
@@ -11,7 +11,7 @@ type ErrorType = {
 };
 
 export default makeCheck<ErrorType>({
-  validate: (workspace, allWorkspaces) => {
+  validate: (workspace, _allWorkspaces) => {
     if (isNodePackage(workspace)) {
       let dependencies = new Set<string>();
       let errors: ErrorType[] = [];

--- a/packages/cli/src/checks/MULTIPLE_DEPENDENCY_TYPES.ts
+++ b/packages/cli/src/checks/MULTIPLE_DEPENDENCY_TYPES.ts
@@ -1,10 +1,11 @@
 import { makeCheck } from "./utils.ts";
 import { isNodePackage } from "@manypkg/tools";
 import type { Package } from "@manypkg/get-packages";
+import type { PackageJSON } from "@manypkg/tools";
 
 type ErrorType = {
   type: "MULTIPLE_DEPENDENCY_TYPES";
-  workspace: Package;
+  workspace: Package<PackageJSON>;
   dependencyType: "devDependencies" | "optionalDependencies";
   dependencyName: string;
 };

--- a/packages/cli/src/checks/ROOT_HAS_PROD_DEPENDENCIES.ts
+++ b/packages/cli/src/checks/ROOT_HAS_PROD_DEPENDENCIES.ts
@@ -2,10 +2,11 @@ import { makeCheck, sortObject } from "./utils.ts";
 import { isNodePackage } from "@manypkg/tools";
 import pc from "picocolors";
 import type { Package } from "@manypkg/get-packages";
+import type { PackageJSON } from "@manypkg/tools";
 
 type ErrorType = {
   type: "ROOT_HAS_PROD_DEPENDENCIES";
-  workspace: Package;
+  workspace: Package<PackageJSON>;
 };
 
 export default makeCheck<ErrorType>({

--- a/packages/cli/src/checks/UNSORTED_DEPENDENCIES.ts
+++ b/packages/cli/src/checks/UNSORTED_DEPENDENCIES.ts
@@ -9,7 +9,7 @@ import type { Package } from "@manypkg/get-packages";
 
 type ErrorType = {
   type: "UNSORTED_DEPENDENCIES";
-  workspace: Package;
+  workspace: Package<any>;
 };
 
 export default makeCheck<ErrorType>({

--- a/packages/cli/src/checks/UNSORTED_DEPENDENCIES.ts
+++ b/packages/cli/src/checks/UNSORTED_DEPENDENCIES.ts
@@ -1,4 +1,4 @@
-import { isDenoPackage, isNodePackage, type DenoJSON } from "@manypkg/tools";
+import { isDenoPackage, isNodePackage } from "@manypkg/tools";
 import {
   makeCheck,
   DEPENDENCY_TYPES,

--- a/packages/cli/src/checks/WORKSPACE_REQUIRED.ts
+++ b/packages/cli/src/checks/WORKSPACE_REQUIRED.ts
@@ -11,7 +11,7 @@ type ErrorType = {
 };
 
 export default makeCheck<ErrorType>({
-  validate: (workspace, allWorkspaces, root, opts) => {
+  validate: (workspace, allWorkspaces, _root, opts) => {
     if (opts.workspaceProtocol !== "require") return [];
     if (isNodePackage(workspace)) {
       let errors: ErrorType[] = [];

--- a/packages/cli/src/checks/WORKSPACE_REQUIRED.ts
+++ b/packages/cli/src/checks/WORKSPACE_REQUIRED.ts
@@ -1,10 +1,11 @@
 import { makeCheck, NORMAL_DEPENDENCY_TYPES } from "./utils.ts";
 import { isNodePackage } from "@manypkg/tools";
 import type { Package } from "@manypkg/get-packages";
+import type { PackageJSON } from "@manypkg/tools";
 
 type ErrorType = {
   type: "WORKSPACE_REQUIRED";
-  workspace: Package;
+  workspace: Package<PackageJSON>;
   depType: (typeof NORMAL_DEPENDENCY_TYPES)[number];
   depName: string;
 };

--- a/packages/cli/src/checks/__tests__/EXTERNAL_MISMATCH_deno.test.ts
+++ b/packages/cli/src/checks/__tests__/EXTERNAL_MISMATCH_deno.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect } from "vitest";
 import fixturez from "fixturez";
 import check from "../EXTERNAL_MISMATCH.ts";
 import { getPackages } from "@manypkg/get-packages";
-import { isDenoPackage, type DenoJSON } from "@manypkg/tools";
+import { isDenoPackage } from "@manypkg/tools";
 
 const f = fixturez(__dirname);
 

--- a/packages/cli/src/checks/__tests__/INTERNAL_MISMATCH_deno.test.ts
+++ b/packages/cli/src/checks/__tests__/INTERNAL_MISMATCH_deno.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect } from "vitest";
 import fixturez from "fixturez";
 import check from "../INTERNAL_MISMATCH.ts";
 import { getPackages } from "@manypkg/get-packages";
-import { isDenoPackage, type DenoJSON } from "@manypkg/tools";
+import { isDenoPackage } from "@manypkg/tools";
 
 const f = fixturez(__dirname);
 

--- a/packages/cli/src/checks/__tests__/UNSORTED_DEPENDENCIES_deno.test.ts
+++ b/packages/cli/src/checks/__tests__/UNSORTED_DEPENDENCIES_deno.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect } from "vitest";
 import fixturez from "fixturez";
 import check from "../UNSORTED_DEPENDENCIES.ts";
 import { getPackages } from "@manypkg/get-packages";
-import { isDenoPackage, type DenoJSON } from "@manypkg/tools";
+import { isDenoPackage } from "@manypkg/tools";
 
 const f = fixturez(__dirname);
 

--- a/packages/cli/src/checks/__tests__/test-helpers.ts
+++ b/packages/cli/src/checks/__tests__/test-helpers.ts
@@ -2,7 +2,7 @@ import type { Package } from "@manypkg/get-packages";
 import type { PackageJSON } from "@manypkg/tools";
 import crypto from "node:crypto";
 
-export let getRootWS = (): Package & { packageJson: PackageJSON } => {
+export let getRootWS = (): Package<PackageJSON> => {
   return {
     dir: `fake/monorepo`,
     relativeDir: ".",
@@ -18,7 +18,7 @@ export let getRootWS = (): Package & { packageJson: PackageJSON } => {
 export let getFakeWS = (
   name: string = "pkg-1",
   version: string = "1.0.0"
-): Package & { packageJson: PackageJSON } => {
+): Package<PackageJSON> => {
   return {
     dir: `fake/monorepo/packages/${name}`,
     relativeDir: `packages/${name}`,
@@ -30,7 +30,7 @@ export let getFakeWS = (
   };
 };
 
-export let getWS = (): Map<string, Package & { packageJson: PackageJSON }> => {
+export let getWS = (): Map<string, Package<PackageJSON>> => {
   let pkg = new Map();
   pkg.set("pkg-1", getFakeWS());
   return pkg;

--- a/packages/cli/src/checks/utils.ts
+++ b/packages/cli/src/checks/utils.ts
@@ -25,8 +25,8 @@ export type Options = {
 type RootCheck<ErrorType> = {
   type: "root";
   validate: (
-    rootPackage: Package,
-    allPackages: Map<string, Package>,
+    rootPackage: Package<any>,
+    allPackages: Map<string, Package<any>>,
     options: Options
   ) => ErrorType[];
   fix?: (
@@ -39,8 +39,8 @@ type RootCheck<ErrorType> = {
 type RootCheckWithFix<ErrorType> = {
   type: "root";
   validate: (
-    rootPackage: Package,
-    allPackages: Map<string, Package>,
+    rootPackage: Package<any>,
+    allPackages: Map<string, Package<any>>,
     options: Options
   ) => ErrorType[];
   fix: (
@@ -53,9 +53,9 @@ type RootCheckWithFix<ErrorType> = {
 type AllCheck<ErrorType> = {
   type: "all";
   validate: (
-    workspace: Package,
-    allWorkspaces: Map<string, Package>,
-    rootWorkspace: Package | undefined,
+    workspace: Package<any>,
+    allWorkspaces: Map<string, Package<any>>,
+    rootWorkspace: Package<any> | undefined,
     options: Options
   ) => ErrorType[];
   fix?: (
@@ -68,9 +68,9 @@ type AllCheck<ErrorType> = {
 type AllCheckWithFix<ErrorType> = {
   type: "all";
   validate: (
-    workspace: Package,
-    allWorkspaces: Map<string, Package>,
-    rootWorkspace: Package | undefined,
+    workspace: Package<any>,
+    allWorkspaces: Map<string, Package<any>>,
+    rootWorkspace: Package<any> | undefined,
     options: Options
   ) => ErrorType[];
   fix: (
@@ -89,7 +89,7 @@ export function sortObject(prevObj: { [key: string]: string }) {
   return newObj;
 }
 
-export function sortDeps(pkg: Package) {
+export function sortDeps(pkg: Package<any>) {
   if (isDenoPackage(pkg)) {
     if (pkg.packageJson.imports) {
       pkg.packageJson.imports = sortObject(pkg.packageJson.imports || {});
@@ -119,7 +119,7 @@ function weakMemoize<Arg, Ret>(func: (arg: Arg) => Ret): (arg: Arg) => Ret {
 }
 
 export let getMostCommonRangeMap = weakMemoize(function getMostCommonRanges(
-  allPackages: Map<string, Package>
+  allPackages: Map<string, Package<any>>
 ) {
   let dependencyRangesMapping = new Map<string, { [key: string]: number }>();
 

--- a/packages/cli/src/checks/utils.ts
+++ b/packages/cli/src/checks/utils.ts
@@ -1,7 +1,7 @@
 import type { Package } from "@manypkg/get-packages";
 import * as semver from "semver";
 import { highest } from "sembear";
-import { isDenoPackage, isNodePackage, type DenoJSON } from "@manypkg/tools";
+import { isDenoPackage, isNodePackage } from "@manypkg/tools";
 
 export const NORMAL_DEPENDENCY_TYPES = [
   "dependencies",
@@ -123,7 +123,7 @@ export let getMostCommonRangeMap = weakMemoize(function getMostCommonRanges(
 ) {
   let dependencyRangesMapping = new Map<string, { [key: string]: number }>();
 
-  for (let [pkgName, pkg] of allPackages) {
+  for (let [_pkgName, pkg] of allPackages) {
     if (isDenoPackage(pkg)) {
       if (pkg.dependencies) {
         for (let depName in pkg.dependencies) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,4 +1,3 @@
-import path from "node:path";
 import * as logger from "./logger.ts";
 import {
   getPackages,
@@ -155,7 +154,7 @@ async function execCmd(args: string[]) {
   );
   if (shouldFix) {
     await Promise.all(
-      [...packagesByName].map(async ([pkgName, workspace]) => {
+      [...packagesByName].map(async ([_pkgName, workspace]) => {
         writePackage(workspace);
       })
     );

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,6 +5,7 @@ import {
   type Packages,
   type Package,
 } from "@manypkg/get-packages";
+import type { PackageJSON } from "@manypkg/tools";
 import type { Options } from "./checks/utils.ts";
 import { checks } from "./checks/index.ts";
 import { ExitError } from "./errors.ts";
@@ -15,7 +16,7 @@ import { npmTagAll } from "./npm-tag.ts";
 import { exec } from "tinyexec";
 import pLimit from "p-limit";
 
-type RootPackage = Package & {
+type RootPackage = Package<PackageJSON> & {
   packageJson: {
     manypkg?: Options;
   };
@@ -29,7 +30,7 @@ let defaultOptions = {
 };
 
 let runChecks = (
-  allWorkspaces: Map<string, Package>,
+  allWorkspaces: Map<string, Package<any>>,
   rootWorkspace: RootPackage | undefined,
   shouldFix: boolean,
   options: Options
@@ -140,7 +141,7 @@ async function execCmd(args: string[]) {
     ...rootPackage?.packageJson.manypkg,
   };
 
-  let packagesByName = new Map<string, Package>(
+  let packagesByName = new Map<string, Package<any>>(
     packages.map((x) => [x.packageJson.name, x])
   );
   if (rootPackage) {

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -24,7 +24,7 @@ function getRunArgs(tool: string, args: string[]) {
 export async function runCmd(args: string[], cwd: string) {
   let { packages, tool } = await getPackages(cwd);
 
-  let pkg: Package | undefined;
+  let pkg: Package<any> | undefined;
 
   const exactMatchingPackage = packages.find((pkg) => {
     return pkg.packageJson.name === args[0] || pkg.relativeDir === args[0];

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -8,7 +8,6 @@ import {
   isNodePackage,
   findDenoConfigSync,
 } from "@manypkg/tools";
-import * as jsonc from "jsonc-parser";
 
 export async function writePackage(pkg: Package<any>) {
   if (isDenoPackage(pkg)) {

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -10,7 +10,7 @@ import {
 } from "@manypkg/tools";
 import * as jsonc from "jsonc-parser";
 
-export async function writePackage(pkg: Package) {
+export async function writePackage(pkg: Package<any>) {
   if (isDenoPackage(pkg)) {
     const fileName = findDenoConfigSync(pkg.dir);
     if (!fileName) {

--- a/packages/get-packages/src/index.test.ts
+++ b/packages/get-packages/src/index.test.ts
@@ -193,7 +193,7 @@ let runTests = (getPackages: GetPackages) => {
 
   it("should throw an error if a package.json is missing the name field", async () => {
     try {
-      const allPackages = await getPackagesSync(f.copy("no-name-field"));
+      getPackagesSync(f.copy("no-name-field"));
     } catch (err) {
       expect(
         !!err && typeof err === "object" && "message" in err && err.message

--- a/packages/tools/src/BunTool.ts
+++ b/packages/tools/src/BunTool.ts
@@ -101,7 +101,7 @@ export const BunTool: Tool = {
       const packageGlobs: string[] = pkgJson.workspaces || [];
 
       const packages = await expandPackageGlobs(packageGlobs, rootDir, BunTool);
-      const rootPackage: Package = {
+      const rootPackage: Package<BunPackageJSON> = {
         dir: rootDir,
         relativeDir: ".",
         packageJson: pkgJson,
@@ -132,7 +132,7 @@ export const BunTool: Tool = {
       const packageGlobs: string[] = pkgJson.workspaces || [];
 
       const packages = expandPackageGlobsSync(packageGlobs, rootDir, BunTool);
-      const rootPackage: Package = {
+      const rootPackage: Package<BunPackageJSON> = {
         dir: rootDir,
         relativeDir: ".",
         packageJson: pkgJson,

--- a/packages/tools/src/DenoTool.ts
+++ b/packages/tools/src/DenoTool.ts
@@ -57,8 +57,10 @@ import {
 const dependencyRegexp =
   /^(?<protocol>jsr:|npm:|https:|http:)(?:\/\/|\/)?(?<name>@?[^@\s]+)@?(?<version>[^?\s/]+)?/;
 
-function extractDependencies(json: DenoJSON): Package["dependencies"] {
-  const dependencies: Package["dependencies"] = {};
+function extractDependencies(
+  json: DenoJSON
+): Package<DenoJSON>["dependencies"] {
+  const dependencies: Package<DenoJSON>["dependencies"] = {};
   if (!json.imports) {
     return dependencies;
   }
@@ -125,13 +127,13 @@ export const DenoTool: Tool = {
       const packageGlobs: string[] = pkgJson.workspace!;
       const packages = await expandDenoGlobs(packageGlobs, rootDir, DenoTool);
 
-      const rootPackage: Package = {
+      const rootPackage: Package<DenoJSON> = {
         dir: rootDir,
         relativeDir: ".",
         packageJson: pkgJson,
         tool: DenoTool,
+        dependencies: extractDependencies(pkgJson),
       };
-      rootPackage.dependencies = extractDependencies(rootPackage.packageJson);
 
       return {
         tool: DenoTool,
@@ -164,13 +166,13 @@ export const DenoTool: Tool = {
       const packageGlobs: string[] = pkgJson.workspace!;
       const packages = expandDenoGlobsSync(packageGlobs, rootDir, DenoTool);
 
-      const rootPackage: Package = {
+      const rootPackage: Package<DenoJSON> = {
         dir: rootDir,
         relativeDir: ".",
         packageJson: pkgJson,
         tool: DenoTool,
+        dependencies: extractDependencies(pkgJson),
       };
-      rootPackage.dependencies = extractDependencies(rootPackage.packageJson);
 
       return {
         tool: DenoTool,

--- a/packages/tools/src/LernaTool.ts
+++ b/packages/tools/src/LernaTool.ts
@@ -64,7 +64,7 @@ export const LernaTool: Tool = {
         rootDir,
         LernaTool
       );
-      const rootPackage: Package = {
+      const rootPackage: Package<PackageJSON> = {
         dir: rootDir,
         relativeDir: ".",
         packageJson: pkgJson,
@@ -96,7 +96,7 @@ export const LernaTool: Tool = {
       const packageGlobs: string[] = lernaJson.packages || ["packages/*"];
 
       const packages = expandPackageGlobsSync(packageGlobs, rootDir, LernaTool);
-      const rootPackage: Package = {
+      const rootPackage: Package<PackageJSON> = {
         dir: rootDir,
         relativeDir: ".",
         packageJson: pkgJson,

--- a/packages/tools/src/NpmTool.ts
+++ b/packages/tools/src/NpmTool.ts
@@ -72,7 +72,7 @@ export const NpmTool: Tool = {
       const packageGlobs: string[] = pkgJson.workspaces!;
 
       const packages = await expandPackageGlobs(packageGlobs, rootDir, NpmTool);
-      const rootPackage: Package = {
+      const rootPackage: Package<NpmPackageJSON> = {
         dir: rootDir,
         relativeDir: ".",
         packageJson: pkgJson,
@@ -103,7 +103,7 @@ export const NpmTool: Tool = {
       const packageGlobs: string[] = pkgJson.workspaces!;
 
       const packages = expandPackageGlobsSync(packageGlobs, rootDir, NpmTool);
-      const rootPackage: Package = {
+      const rootPackage: Package<NpmPackageJSON> = {
         dir: rootDir,
         relativeDir: ".",
         packageJson: pkgJson,

--- a/packages/tools/src/PnpmTool.ts
+++ b/packages/tools/src/PnpmTool.ts
@@ -79,7 +79,7 @@ export const PnpmTool: Tool = {
         rootDir,
         PnpmTool
       );
-      const rootPackage: Package = {
+      const rootPackage: Package<PackageJSON> = {
         dir: rootDir,
         relativeDir: ".",
         packageJson: pkgJson,
@@ -113,7 +113,7 @@ export const PnpmTool: Tool = {
       const packageGlobs: string[] = manifest.packages!;
 
       const packages = expandPackageGlobsSync(packageGlobs, rootDir, PnpmTool);
-      const rootPackage: Package = {
+      const rootPackage: Package<PackageJSON> = {
         dir: rootDir,
         relativeDir: ".",
         packageJson: pkgJson,

--- a/packages/tools/src/RootTool.ts
+++ b/packages/tools/src/RootTool.ts
@@ -27,7 +27,7 @@ export const RootTool: Tool = {
 
     try {
       const pkgJson = (await readJson(rootDir, "package.json")) as PackageJSON;
-      const pkg: Package = {
+      const pkg: Package<PackageJSON> = {
         dir: rootDir,
         relativeDir: ".",
         packageJson: pkgJson,
@@ -55,7 +55,7 @@ export const RootTool: Tool = {
 
     try {
       const pkgJson = readJsonSync(rootDir, "package.json") as PackageJSON;
-      const pkg: Package = {
+      const pkg: Package<PackageJSON> = {
         dir: rootDir,
         relativeDir: ".",
         packageJson: pkgJson,

--- a/packages/tools/src/RushTool.ts
+++ b/packages/tools/src/RushTool.ts
@@ -65,7 +65,7 @@ export const RushTool: Tool = {
       const directories = rushJson.projects.map((project) =>
         path.resolve(rootDir, project.projectFolder)
       );
-      const packages: Package[] = await Promise.all(
+      const packages: Package<PackageJSON>[] = await Promise.all(
         directories.map(async (dir: string) => {
           return {
             dir,
@@ -108,15 +108,17 @@ export const RushTool: Tool = {
       const directories = rushJson.projects.map((project) =>
         path.resolve(rootDir, project.projectFolder)
       );
-      const packages: Package[] = directories.map((dir: string) => {
-        const packageJson: PackageJSON = readJsonSync(dir, "package.json");
-        return {
-          dir,
-          relativeDir: path.relative(directory, dir),
-          packageJson,
-          tool: RushTool,
-        };
-      });
+      const packages: Package<PackageJSON>[] = directories.map(
+        (dir: string) => {
+          const packageJson: PackageJSON = readJsonSync(dir, "package.json");
+          return {
+            dir,
+            relativeDir: path.relative(directory, dir),
+            packageJson,
+            tool: RushTool,
+          };
+        }
+      );
 
       // Rush does not have a root package
       return {

--- a/packages/tools/src/Tool.ts
+++ b/packages/tools/src/Tool.ts
@@ -16,6 +16,7 @@ type PublishConfig = {
 export type PackageJSON = {
   name: string;
   version: string;
+  repository?: any;
 
   // dependency maps (optional)
   dependencies?: DependencyMap;
@@ -36,11 +37,11 @@ export type PackageJSON = {
  */
 import type { DenoJSON } from "./DenoTool.ts";
 
-export interface Package {
+export interface Package<T extends PackageJSON | DenoJSON> {
   /**
    * The pre-loaded package json structure.
    */
-  packageJson: PackageJSON | DenoJSON;
+  packageJson: T;
   dependencies?: Record<
     string,
     {
@@ -79,12 +80,12 @@ export interface Packages {
   /**
    * A collection of disocvered packages.
    */
-  packages: Package[];
+  packages: Package<any>[];
 
   /**
    * If supported by the tool, this is the "root package" for the monorepo.
    */
-  rootPackage?: Package;
+  rootPackage?: Package<any>;
 
   /**
    * The absolute path of the root directory of this monorepo.
@@ -135,15 +136,11 @@ export type ToolType =
  * Each tool defines a common interface for detecting whether a directory is
  * a valid instance of this type of monorepo, how to retrieve the packages, etc.
  */
-export function isDenoPackage(
-  pkg: Package
-): pkg is Package & { packageJson: DenoJSON } {
+export function isDenoPackage(pkg: Package<any>): pkg is Package<DenoJSON> {
   return pkg.tool.type === "deno";
 }
 
-export function isNodePackage(
-  pkg: Package
-): pkg is Package & { packageJson: PackageJSON } {
+export function isNodePackage(pkg: Package<any>): pkg is Package<PackageJSON> {
   return pkg.tool.type !== "deno";
 }
 

--- a/packages/tools/src/Tool.ts
+++ b/packages/tools/src/Tool.ts
@@ -1,3 +1,5 @@
+import type { DenoJSON } from "./DenoTool.ts";
+
 /**
  * An in-memory representation of a package.json file.
  */
@@ -35,7 +37,6 @@ export type PackageJSON = {
  * An individual package json structure, along with the directory it lives in,
  * relative to the root of the current monorepo.
  */
-import type { DenoJSON } from "./DenoTool.ts";
 
 export interface Package<T extends PackageJSON | DenoJSON> {
   /**

--- a/packages/tools/src/YarnTool.ts
+++ b/packages/tools/src/YarnTool.ts
@@ -87,7 +87,7 @@ export const YarnTool: Tool = {
         rootDir,
         YarnTool
       );
-      const rootPackage: Package = {
+      const rootPackage: Package<YarnPackageJSON> = {
         dir: rootDir,
         relativeDir: ".",
         packageJson: pkgJson,
@@ -120,7 +120,7 @@ export const YarnTool: Tool = {
         : pkgJson.workspaces!.packages;
 
       const packages = expandPackageGlobsSync(packageGlobs, rootDir, YarnTool);
-      const rootPackage: Package = {
+      const rootPackage: Package<YarnPackageJSON> = {
         dir: rootDir,
         relativeDir: ".",
         packageJson: pkgJson,

--- a/packages/tools/src/expandDenoGlobs.ts
+++ b/packages/tools/src/expandDenoGlobs.ts
@@ -7,8 +7,10 @@ import type { DenoJSON } from "./DenoTool.ts";
 const dependencyRegexp =
   /^(?<protocol>jsr:|npm:|https:|http:)(?:\/\/|\/)?(?<name>@?[^@\s]+)@?(?<version>[^?\s/]+)?/;
 
-function extractDependencies(json: DenoJSON): Package["dependencies"] {
-  const dependencies: Package["dependencies"] = {};
+function extractDependencies(
+  json: DenoJSON
+): Package<DenoJSON>["dependencies"] {
+  const dependencies: Package<DenoJSON>["dependencies"] = {};
   if (!json.imports) {
     return dependencies;
   }
@@ -35,7 +37,7 @@ async function getDenoPackageFromDir(
   packageDir: string,
   rootDir: string,
   tool: Tool
-): Promise<Package | undefined> {
+): Promise<Package<DenoJSON> | undefined> {
   const fullPath = path.resolve(rootDir, packageDir);
   const relativeDir = path.relative(rootDir, fullPath);
 
@@ -70,7 +72,7 @@ function getDenoPackageFromDirSync(
   packageDir: string,
   rootDir: string,
   tool: Tool
-): Package | undefined {
+): Package<DenoJSON> | undefined {
   const fullPath = path.resolve(rootDir, packageDir);
   const relativeDir = path.relative(rootDir, fullPath);
 
@@ -110,7 +112,7 @@ export async function expandDenoGlobs(
   packageGlobs: string[],
   directory: string,
   tool: Tool
-): Promise<Package[]> {
+): Promise<Package<DenoJSON>[]> {
   const relativeDirectories: string[] = await glob(packageGlobs, {
     cwd: directory,
     onlyDirectories: true,
@@ -121,11 +123,12 @@ export async function expandDenoGlobs(
     .map((p) => path.resolve(directory, p))
     .sort();
 
-  const discoveredPackages: Array<Package | undefined> = await Promise.all(
-    directories.map((dir) => getDenoPackageFromDir(dir, directory, tool))
-  );
+  const discoveredPackages: Array<Package<DenoJSON> | undefined> =
+    await Promise.all(
+      directories.map((dir) => getDenoPackageFromDir(dir, directory, tool))
+    );
 
-  return discoveredPackages.filter((pkg) => pkg) as Package[];
+  return discoveredPackages.filter((pkg) => pkg) as Package<DenoJSON>[];
 }
 
 /**
@@ -135,7 +138,7 @@ export function expandDenoGlobsSync(
   packageGlobs: string[],
   directory: string,
   tool: Tool
-): Package[] {
+): Package<DenoJSON>[] {
   const relativeDirectories: string[] = globSync(packageGlobs, {
     cwd: directory,
     onlyDirectories: true,
@@ -146,9 +149,8 @@ export function expandDenoGlobsSync(
     .map((p) => path.resolve(directory, p))
     .sort();
 
-  const discoveredPackages: Array<Package | undefined> = directories.map(
-    (dir) => getDenoPackageFromDirSync(dir, directory, tool)
-  );
+  const discoveredPackages: Array<Package<DenoJSON> | undefined> =
+    directories.map((dir) => getDenoPackageFromDirSync(dir, directory, tool));
 
-  return discoveredPackages.filter((pkg) => pkg) as Package[];
+  return discoveredPackages.filter((pkg) => pkg) as Package<DenoJSON>[];
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,8 @@
     "noEmit": true,
     "strict": true,
     "target": "esnext",
-    "verbatimModuleSyntax": true
+    "verbatimModuleSyntax": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2441,7 +2441,7 @@ json5@^2.2.3:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
-jsonc-parser@^3.2.0, jsonc-parser@^3.3.1:
+jsonc-parser@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.3.1.tgz#f2a524b4f7fd11e3d791e559977ad60b98b798b4"
   integrity sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==


### PR DESCRIPTION
This commit refactors the `Package` type in `@manypkg/tools` to be a generic type, `Package<T>`, where `T` can be either `PackageJSON` or `DenoJSON`. This change allows for more specific and type-safe handling of Node.js and Deno packages throughout the codebase.

The main changes are:
- The `Package` interface in `packages/tools/src/Tool.ts` is now generic.
- The `isDenoPackage` and `isNodePackage` type guards have been updated to work with the new generic type.
- All package creation sites and type annotations have been updated to use the new generic `Package<T>` type.

This refactoring eliminates the need for ugly type casts and assertions like `as any` and `& { packageJson: PackageJSON }`, which were previously necessary due to the union type on the `packageJson` property. The codebase is now more type-safe and easier to maintain.